### PR TITLE
Support ASN1UTF8String in toDart

### DIFF
--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -131,6 +131,7 @@ dynamic toDart(ASN1Object obj) {
   if (obj is ASN1PrintableString) return obj.stringValue;
   if (obj is ASN1UtcTime) return obj.dateTimeValue;
   if (obj is ASN1IA5String) return obj.stringValue;
+  if (obj is ASN1UTF8String) return obj.utf8StringValue;
   throw ArgumentError(
       'Cannot convert $obj (${obj.runtimeType}) to dart object.');
 }


### PR DESCRIPTION
We use the `jose` library in combination with Keycloak. The latest update 0.2.0 of that library crashes while parsing the issuer of the certificate that is represented as an `ASN1UTF8String`. But this is not handled in the `toDart(...)` function yet.