### PR TITLE
Bump asn1lib to 0.8.1 to fix versioning errors in downstream packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.4
+- Bump `asn1lib` to 0.8.1.
+
 ## 0.1.3
 
 - Support for CertificatePolicies, CrlDistributionPoints and AuthorityInformationAccess extensions

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: x509
 description: Dart library for parsing and working with X.509 certificates.
-version: 0.1.3
+version: 0.1.4
 homepage: https://github.com/appsup-dart/x509
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,10 +4,10 @@ version: 0.1.3
 homepage: https://github.com/appsup-dart/x509
 
 environment:
-  sdk: '>=2.6.0 <3.0.0'
+  sdk: ">=2.6.0 <3.0.0"
 
 dependencies:
-  asn1lib: ^0.6.0
+  asn1lib: ^0.8.1
   quiver: ^2.0.0
   crypto_keys: ^0.1.3
 


### PR DESCRIPTION
Needed to bump `asn1lib` to fix versioning constraint errors in downstream packages like `jose`. All tests still passing.