### PR TITLE
Support unknown policyidentifier

### DIFF
--- a/lib/src/extension.dart
+++ b/lib/src/extension.dart
@@ -381,7 +381,19 @@ class PolicyInformation {
   @override
   String toString([String prefix = '']) {
     var buffer = StringBuffer();
-    buffer.writeln('${prefix}Policy: $policyIdentifier');
+    var piString;
+    try {
+      piString = policyIdentifier.toString();
+    } catch (e) {
+      if(e is UnknownOIDNameError) {
+        // It is unique definition policy. should not convert name.
+        // In this case, to be just combined numbers.
+        piString = policyIdentifier.nodes.map((i) => i.toString()).join('.');
+      } else {
+        rethrow;
+      }
+    }
+    buffer.writeln('${prefix}Policy: $piString');
     buffer.writeln(
         policyQualifiers.map((q) => q.toString('${prefix}\t')).join('\n'));
     return buffer.toString();

--- a/lib/src/extension.dart
+++ b/lib/src/extension.dart
@@ -512,7 +512,7 @@ class CrlDistributionPoints extends ExtensionValue {
 }
 
 class DistributionPoint {
-  final String? name;
+  final DistributionPointName? name;
   final List<DistributionPointReason>? reasons;
   final String? crlIssuer;
 
@@ -525,7 +525,7 @@ class DistributionPoint {
   ///     reasons                 [1]     ReasonFlags OPTIONAL,
   ///     cRLIssuer               [2]     GeneralNames OPTIONAL }
   factory DistributionPoint.fromAsn1(ASN1Sequence sequence) {
-    var name = sequence.elements.isEmpty ? null : toDart(sequence.elements[0]);
+    var name = sequence.elements.isEmpty ? null : DistributionPointName.fromAsn1(ASN1Object.fromBytes(sequence.elements[0].valueBytes()));
     var reasons = sequence.elements.length <= 1
         ? null
         : (sequence.elements[1] as ASN1BitString)
@@ -538,6 +538,56 @@ class DistributionPoint {
     return DistributionPoint(
         name: name, reasons: reasons, crlIssuer: crlIssuer);
   }
+}
+
+class DistributionPointName {
+  final int choice;
+  final GeneralNames? generalNames;
+  final RelativeDistinguishedName? relativeDistinguishedName;
+  static final _choiceName = [
+    'Full Name',
+    'CRLIssuer',
+  ];
+
+  DistributionPointName(this.choice, this.generalNames, this.relativeDistinguishedName);
+
+  // DistributionPointName ::= CHOICE {
+  //   fullName [0] GeneralNames,
+  //   nameRelativeToCRLIssuer [1] RelativeDistinguishedName
+  // }
+  factory DistributionPointName.fromAsn1(ASN1Object obj) {
+    var choice = (0x1F & obj.tag);
+    var childObj = ASN1Parser(obj.valueBytes()).nextObject();
+    var generalNames;
+    var relativeName;
+
+    switch (choice) {
+      case 0:
+        generalNames = GeneralNames.fromAsn1(childObj);
+        break;
+      case 1:
+        relativeName = RelativeDistinguishedName();
+        break;
+      default:
+        throw UnsupportedError('Not supported CHOICE ($choice) by DistributionPointName.');
+    }
+    return DistributionPointName(choice, generalNames, relativeName);
+  }
+
+  @override
+  String toString() {
+    var contentsString;
+    if (generalNames != null) {
+      contentsString = generalNames.toString();
+    } else {
+      contentsString = relativeDistinguishedName.toString();
+    }
+    return '${_choiceName[choice]}: ${contentsString}';
+  }
+}
+
+class RelativeDistinguishedName {
+
 }
 
 enum DistributionPointReason {
@@ -620,7 +670,7 @@ class GeneralName {
     'x400Address',
     'directoryName',
     'ediPartyName',
-    'uniformResourceIdentifier',
+    'URI',
     'IPAddress',
     'registeredID',
   ];
@@ -639,16 +689,19 @@ class GeneralName {
         case 6:
           contents = ASN1IA5String(String.fromCharCodes(obj.valueBytes()));
           break;
-        case 7:
+        case 7: // IPAddress (OctetString)
           contents = ASN1OctetString(obj.valueBytes());
           break;
-        case 8:
+        case 8: // registeredID (ObjectIdentifier)
           contents = ASN1ObjectIdentifier.fromBytes(obj.valueBytes());
           break;
         case 0: // TODO: unimplemented.
         case 3:
         case 4:
-        case 5:
+        case 5: // ediPartyName
+          //  EDIPartyName ::= SEQUENCE {
+          //   nameAssigner            [0]     DirectoryString OPTIONAL,
+          //   partyName               [1]     DirectoryString }
           log('Warning Not Supported CHOICE($choice).');
           contents = obj;
       }
@@ -677,9 +730,20 @@ class GeneralNames extends ExtensionValue {
   GeneralNames(this.names);
 
   //GeneralNames :: = SEQUENCE SIZE (1..MAX) OF GeneralName
-  factory GeneralNames.fromAsn1(ASN1Sequence sequence) {
-    return GeneralNames(sequence.elements.map((n) {
-      return GeneralName.fromAsn1(n);
-    }).toList());
+  factory GeneralNames.fromAsn1(ASN1Object obj) {
+    if(obj is ASN1Sequence) {
+      var sequence = obj;
+      return GeneralNames(sequence.elements.map((n) {
+        return GeneralName.fromAsn1(n);
+      }).toList());
+    } else {
+      var _name = GeneralName.fromAsn1(obj);
+      return GeneralNames([_name]);
+    }
+  }
+
+  @override
+  String toString() {
+    return names.map((n) => n.toString()).join(", ");
   }
 }

--- a/lib/src/objectidentifier.dart
+++ b/lib/src/objectidentifier.dart
@@ -65,7 +65,7 @@ class ObjectIdentifier {
       if (tree is Map) return tree[null];
       return tree;
     } catch (e) {
-      throw StateError(
+      throw UnknownOIDNameError(
           'Unable to get name of ObjectIdentifier with nodes $nodes');
     }
   }
@@ -493,4 +493,10 @@ class ObjectIdentifier {
       }
     }
   };
+}
+
+// Throw when There OID name is unknown.
+// For example, be defined unique extension.
+class UnknownOIDNameError extends StateError {
+  UnknownOIDNameError(String message): super(message);
 }

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -244,10 +244,24 @@ dynamic toDart(ASN1Object obj) {
   if (obj is ASN1UtcTime) return obj.dateTimeValue;
   if (obj is ASN1IA5String) return obj.stringValue;
   if (obj is ASN1UTF8String) return obj.utf8StringValue;
+
+  // ASN.1 Identifier format is below:
+  // | 7 | 6 |  5  | 4| 3| 2|1|0|
+  // | Class | P/C | Tag number |
+  //
+  // The Class type is below:
+  // 0 0(0): Universal
+  // 0 1(1): Applicaation
+  // 1 0(2): Context-Specific
+  // 1 1(3): Private
+  //
+  // The P/C is below:
+  // 0: Primitive
+  // 1: Constructed
   switch (obj.tag) {
-    case 0xa0:
+    case 0xa0: // 10 1 00000 => Class is Context-Specific, P/C is Constructed and Tag Number is 0
       return toDart(ASN1Parser(obj.valueBytes()).nextObject());
-    case 0x86:
+    case 0x86: // 10 0 00110 => Class is Context-Specific, P/C is Primitive and Tag Number is 6
       return utf8.decode(obj.valueBytes());
   }
   throw ArgumentError(

--- a/lib/src/x509_base.dart
+++ b/lib/src/x509_base.dart
@@ -235,6 +235,7 @@ Object _parseDer(List<int> bytes, String? type) {
       // Encrypted Private Key file (PKCS#8)
       return EncryptedPrivateKeyInfo.fromAsn1(s);
     case '':
+    case 'CERTIFICATE':
       return X509Certificate.fromAsn1(s);
     case 'CERTIFICATE REQUEST':
       return CertificationRequest.fromAsn1(s);

--- a/test/objectidentifier_test.dart
+++ b/test/objectidentifier_test.dart
@@ -1,0 +1,16 @@
+import 'package:test/test.dart';
+import 'package:x509/x509.dart';
+
+void main() {
+  group('name', () {
+    test('return correct name', () {
+      var oid = ObjectIdentifier([2, 5, 4, 3]);
+      expect(oid.name, 'commonName');
+    });
+
+    test('throw UnknownOIDNameError when unknown oid', () {
+      var oid = ObjectIdentifier([1, 2, 3, 4, 5, 6]);
+      expect(() => oid.name, throwsA(TypeMatcher<UnknownOIDNameError>()));
+    });
+  });
+}

--- a/test/x509_test.dart
+++ b/test/x509_test.dart
@@ -309,4 +309,83 @@ void main() {
       }
     });
   });
+
+  group('PolicyInformation', () {
+    var subject = ASN1Sequence.fromBytes(Uint8List.fromList([
+      0x30,
+      0x3b,
+      0x6,
+      0xb,
+      0x2a,
+      0x83,
+      0x78,
+      0x8f,
+      0x8f,
+      0x00,
+      0x8,
+      0x5,
+      0x1,
+      0x3,
+      0x1e,
+      0x30,
+      0x2c,
+      0x30,
+      0x2a,
+      0x6,
+      0x8,
+      0x2b,
+      0x6,
+      0x1,
+      0x5,
+      0x5,
+      0x7,
+      0x2,
+      0x1,
+      0x16,
+      0x24,
+      0x68,
+      0x74,
+      0x74,
+      0x70,
+      0x3a,
+      0x2f,
+      0x2f,
+      0x77,
+      0x77,
+      0x77,
+      0x2e,
+      0x65,
+      0x78,
+      0x61,
+      0x6d,
+      0x70,
+      0x6c,
+      0x65,
+      0x2e,
+      0x63,
+      0x6f,
+      0x6d,
+      0x2f,
+      0x74,
+      0x65,
+      0x73,
+      0x74,
+      0x5f,
+      0x63,
+      0x70,
+      0x73,
+      0x2e,
+      0x68,
+      0x74,
+      0x6d,
+      0x6c
+    ]));
+    test('should not be convert when set unknown policy identifier', () {
+      var pi = PolicyInformation.fromAsn1(subject);
+      var expectStr = 'Policy: 1.2.504.247680.8.5.1.3.30\n' +
+          '\tCPS: http://www.example.com/test_cps.html\n' +
+          '';
+      expect(pi.toString(), expectStr);
+    });
+  });
 }

--- a/test/x509_test.dart
+++ b/test/x509_test.dart
@@ -191,7 +191,7 @@ void main() {
     });
   });
 
-  group('v3 extension', () {
+  group('v3 extension General Name', () {
     var generalNameEncodeBytes = [
       48,
       19,
@@ -228,6 +228,65 @@ void main() {
       var oid = ObjectIdentifier([2, 5, 29, 17]);
       var c = ExtensionValue.fromAsn1(extension, oid) as GeneralNames;
       expect(c.names[0].toString(), 'DNS:www.chaintope.com');
+    });
+  });
+
+  group('v3 extension DistributionPoint', () {
+    var asn1Seq = ASN1Sequence.fromBytes(Uint8List.fromList([
+      0x30,
+      0x2d,
+      0xa0,
+      0x2b,
+      0xa0,
+      0x29,
+      0x86,
+      0x27,
+      0x68,
+      0x74,
+      0x74,
+      0x70,
+      0x3a,
+      0x2f,
+      0x2f,
+      0x63,
+      0x72,
+      0x6c,
+      0x2e,
+      0x65,
+      0x78,
+      0x61,
+      0x6d,
+      0x70,
+      0x6c,
+      0x65,
+      0x2e,
+      0x63,
+      0x6f,
+      0x6d,
+      0x2f,
+      0x66,
+      0x6c,
+      0x75,
+      0x74,
+      0x74,
+      0x65,
+      0x72,
+      0x5f,
+      0x74,
+      0x65,
+      0x73,
+      0x74,
+      0x2e,
+      0x63,
+      0x72,
+      0x6c
+    ]));
+
+    test('URL only  Distribution Point', () {
+      var dp = DistributionPoint.fromAsn1(asn1Seq);
+      expect(dp.name.toString(),
+          'Full Name: URI:http://crl.example.com/flutter_test.crl');
+      expect(dp.name, isA<DistributionPointName>());
     });
   });
 


### PR DESCRIPTION
# Description
There can call toString() of the PolicyIdentifier that has unknown id.

The PolicyIdentifier should be allow to set the id that is defined as unique extension.