### PR TITLE
correct tag handling in toDart function

### DIFF
--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -264,10 +264,10 @@ dynamic toDart(ASN1Object obj) {
   // The P/C is below:
   // 0: Primitive
   // 1: Constructed
-  switch (obj.tag) {
+  switch (obj.tag & 0xe0) {
     case 0xa0: // 10 1 00000 => Class is Context-Specific, P/C is Constructed and Tag Number is 0
       return toDart(ASN1Parser(obj.valueBytes()).nextObject());
-    case 0x86: // 10 0 00110 => Class is Context-Specific, P/C is Primitive and Tag Number is 6
+    case 0x80: // 10 0 00110 => Class is Context-Specific, P/C is Primitive and Tag Number is 0
       return utf8.decode(obj.valueBytes());
   }
   throw ArgumentError(


### PR DESCRIPTION
changed to allow conversion of Tag Number other than 0. there is no need to limit conversion only to Tag number 0.